### PR TITLE
 update ucrop version to support 16kb and update multiple select photos to support maxfiles

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,7 @@ android {
 dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
-    implementation 'com.github.yalantis:ucrop:2.2.6-native'
+    implementation 'com.github.yalantis:ucrop:2.2.11-native'
     implementation 'androidx.activity:activity:1.9.2'
     implementation "androidx.core:core:1.13.1"
 }

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -727,9 +727,10 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
             options.setToolbarColor(Color.parseColor(cropperToolbarColor));
         }
 
-        if (cropperStatusBarColor != null) {
-            options.setStatusBarColor(Color.parseColor(cropperStatusBarColor));
-        }
+        // 在uCrop的2.2.11-native版本中已经移除了setStatusBarColor方法，代替使用的是setStatusBarLight
+        // if (cropperStatusBarColor != null) {
+        //     options.setStatusBarColor(Color.parseColor(cropperStatusBarColor));
+        // }
 
         if (cropperToolbarWidgetColor != null) {
             options.setToolbarWidgetColor(Color.parseColor(cropperToolbarWidgetColor));

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -102,6 +102,8 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
     private int width = 0;
     private int height = 0;
 
+    private int maxFiles = 5;
+
     private Uri mCameraCaptureURI;
     private String mCurrentMediaPath;
     private ResultCollector resultCollector = new ResultCollector();
@@ -133,6 +135,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         includeExif = options.hasKey("includeExif") && options.getBoolean("includeExif");
         width = options.hasKey("width") ? options.getInt("width") : 0;
         height = options.hasKey("height") ? options.getInt("height") : 0;
+        maxFiles = options.hasKey("maxFiles") ? options.getInt("maxFiles") : maxFiles;
         cropping = options.hasKey("cropping") && options.getBoolean("cropping");
         cropperActiveWidgetColor = options.hasKey("cropperActiveWidgetColor") ? options.getString("cropperActiveWidgetColor") : null;
         cropperStatusBarColor = options.hasKey("cropperStatusBarColor") ? options.getString("cropperStatusBarColor") : null;
@@ -386,7 +389,7 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
             Intent intent;
 
             if (multiple) {
-                intent = new ActivityResultContracts.PickMultipleVisualMedia().createIntent(activity, request);
+                intent = new ActivityResultContracts.PickMultipleVisualMedia(maxFiles).createIntent(activity, request);
             } else {
                 intent = new ActivityResultContracts.PickVisualMedia().createIntent(activity, request);
             }


### PR DESCRIPTION
1. 升级uCrop依赖库到2.2.11-native版本，以支持16kb。
2. 由于uCrop方法中移除了setStatusBarColor方法，所以将PickModule中对该方法的调用进行移除。
3. 修改该组件在Android中选照片时没有支持最大数量限制的问题。